### PR TITLE
ci: Don't build sd-image or kexec-bundle

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -14,8 +14,6 @@ done
 echo "On branch: $BRANCH_NAME"
 if [[ "$BRANCH_NAME" == "main" ]]; then
     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 -- result/iso/iso/*.iso root@caligari:/var/www/ramona.fun/builds/nixos-latest.iso
-    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 -- result/kexec-bundle root@caligari:/var/www/ramona.fun/builds/kexec-bundle
-    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 -- result/ananas-sd-image root@caligari:/var/www/ramona.fun/builds/ananas-sd-image
 
     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 -- *-closure root@caligari:/var/www/ramona.fun/builds/
 

--- a/flake.nix
+++ b/flake.nix
@@ -205,8 +205,6 @@
           "mkdir -p $out/hosts\n"
           + (pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (k: p: "ln -s ${p} $out/hosts/${k}") allClosures))
           + "\nln -s ${self.nixosConfigurations.iso.config.system.build.isoImage} $out/iso\n"
-          + "\nln -s ${self.nixosConfigurations.iso.config.formats.kexec-bundle} $out/kexec-bundle\n"
-          + "\nln -s ${self.nixosConfigurations.ananas.config.formats.sd-aarch64-installer} $out/ananas-sd-image\n"
         );
       default = coverage;
     };


### PR DESCRIPTION
Those don't work anyway, and fail builds because of zfs-kernel