### PR TITLE
hallewell: Downgrade kernel to 6.8

### DIFF
--- a/machines/hallewell/hardware.nix
+++ b/machines/hallewell/hardware.nix
@@ -1,4 +1,8 @@
-{lib, ...}: {
+{
+  lib,
+  pkgs,
+  ...
+}: {
   config = {
     boot = {
       initrd.availableKernelModules = ["xhci_pci" "ahci" "nvme" "usbhid" "usb_storage" "sd_mod" "sr_mod" "bcache" "amdgpu"];
@@ -7,6 +11,7 @@
       extraModulePackages = [];
       loader.systemd-boot.enable = true;
       loader.efi.canTouchEfiVariables = true;
+      kernelPackages = pkgs.linuxPackages_6_8;
     };
     powerManagement.powertop.enable = true;
     fileSystems = {


### PR DESCRIPTION
6.9 seems to be causing issues with stablity, wait till https://github.com/koverstreet/bcachefs/issues/680 is resolved to return to newer kernels.