### PR TITLE
hallewell: Do not override kernel version

### DIFF
--- a/machines/hallewell/hardware.nix
+++ b/machines/hallewell/hardware.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  pkgs,
-  ...
-}: {
+{lib, ...}: {
   config = {
     boot = {
       initrd.availableKernelModules = ["xhci_pci" "ahci" "nvme" "usbhid" "usb_storage" "sd_mod" "sr_mod" "bcache" "amdgpu"];
@@ -11,7 +7,6 @@
       extraModulePackages = [];
       loader.systemd-boot.enable = true;
       loader.efi.canTouchEfiVariables = true;
-      kernelPackages = pkgs.linuxPackages_6_8;
     };
     powerManagement.powertop.enable = true;
     fileSystems = {

--- a/machines/shadowmend/hardware.nix
+++ b/machines/shadowmend/hardware.nix
@@ -10,7 +10,7 @@
     };
     services.logind.lidSwitch = "ignore";
     fileSystems."/" = {
-      device = "/dev/sdb1:/dev/sda1";
+      device = "/dev/disk/by-id/ata-Samsung_SSD_850_EVO_250GB_S3R0NF0JA23099Z-part1";
       fsType = "bcachefs";
     };
 


### PR DESCRIPTION
Turns out the bcachefs woes don't get better on 6.8.