### PR TITLE
blackwood/hallewell: Make backups go over public internet

### DIFF
--- a/machines/blackwood/networking.nix
+++ b/machines/blackwood/networking.nix
@@ -7,4 +7,7 @@ _: {
       "100.0.0.0/8"
     ];
   };
+
+  # so backups can skip tailscale
+  networking.firewall.allowedTCPPorts = [22];
 }

--- a/machines/hallewell/nas/backup.nix
+++ b/machines/hallewell/nas/backup.nix
@@ -6,7 +6,8 @@
         Persistent = true;
         RandomizedDelaySec = "30m";
       };
-      repository = "sftp:root@blackwood:/var/backups/${config.networking.hostName}/";
+      # TODO use a DNS name instead
+      repository = "sftp:root@:37.27.125.251/var/backups/${config.networking.hostName}/";
       passwordFile = config.age.secrets."restic-repository-password".path;
       paths = [
         "/mnt/nas3/data/"


### PR DESCRIPTION
Tailscale slows them down too much, and ssh is encrypted anyway