### PR TITLE
blackwood: Make ssh available only over tailscale

### DIFF
--- a/machines/blackwood/networking.nix
+++ b/machines/blackwood/networking.nix
@@ -7,7 +7,4 @@ _: {
       "100.0.0.0/8"
     ];
   };
-
-  # so backups can skip tailscale
-  networking.firewall.allowedTCPPorts = [22];
 }


### PR DESCRIPTION
Backups are going over syncthing, not SSH, so the comment was outdated.