### PR TITLE
terraform/tailscale: make nodes depend on ACLs

### DIFF
--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -8,6 +8,7 @@ resource "hcloud_network_subnet" "k8s" {
 module "k8s--darkmore" {
   source = "./k8s"
 
+  depends_on    = [tailscale_acl.default]
   name          = "darkmore"
   subnet_id     = hcloud_network_subnet.k8s.id
   dns_zone_name = dnsimple_zone.ramona-fun.name

--- a/terraform/server_crimson.tf
+++ b/terraform/server_crimson.tf
@@ -1,6 +1,7 @@
 module "node--crimson" {
   source = "./node"
 
+  depends_on       = [tailscale_acl.default]
   dns_zone_name    = dnsimple_zone.ramona-fun.name
   name             = "crimson"
   ssh_keys         = [hcloud_ssh_key.ramona.id]

--- a/terraform/server_thornton.tf
+++ b/terraform/server_thornton.tf
@@ -1,6 +1,7 @@
 module "node--thornton" {
   source = "./node"
 
+  depends_on       = [tailscale_acl.default]
   dns_zone_name    = dnsimple_zone.ramona-fun.name
   name             = "thornton"
   ssh_keys         = [hcloud_ssh_key.ramona.id]


### PR DESCRIPTION
This is because ACLs define which tags are available. If a node gets a new tag, and it is defined in the same terraform run, terraform may error out if the ACL (and therefore tag declaration) doesn't get created before the node is.