### PR TITLE
kubernetes: disable the tailscale-nginx role

### DIFF
--- a/.github/scripts/terraform-apply.sh
+++ b/.github/scripts/terraform-apply.sh
@@ -8,4 +8,3 @@ ssh-add ~/.ssh/id_ed25519
 ssh-add -L
 age -d -i ~/.ssh/id_ed25519 plan.tfplan.age >plan.tfplan
 terraform apply -input=false plan.tfplan && rm plan.tfplan
-pkill ssh-agent

--- a/README.md
+++ b/README.md
@@ -93,5 +93,11 @@ Generally the flake should build anywhere, so the machines can be rebuilt by che
 
 # Kubernetes setup
 ```
-kubeadm reset && $(rm /etc/cni/net.d/* || true) && kubeadm init --control-plane-endpoint "127.0.0.1:6444" --apiserver-advertise-address=10.70.0.10  --pod-network-cidr=10.71.0.0/16 --service-cidr=10.72.0.0/16 --upload-certs
+kubeadm reset && $(rm /etc/cni/net.d/* || true) && kubeadm init --control-plane-endpoint "127.0.0.1:6444" --apiserver-advertise-address=10.70.0.10  --pod-network-cidr=10.72.0.0/16 --service-cidr=10.73.0.0/16 --upload-certs
+export KUBECONFIG=/etc/kubernetes/admin.conf
+nix-shell -p kubernetes-helm
+kubectl create ns kube-flannel
+kubectl label --overwrite ns kube-flannel pod-security.kubernetes.io/enforce=privileged
+helm repo add flannel https://flannel-io.github.io/flannel/
+helm install flannel --set podCidr="10.72.0.0/16" --namespace kube-flannel flannel/flannel
 ```

--- a/machine-templates/darkmore-control-plane/default.nix
+++ b/machine-templates/darkmore-control-plane/default.nix
@@ -4,7 +4,6 @@
     ../../roles/hetzner-cloud
     ../../roles/installed
     ../../roles/server-public
-    ../../roles/tailscale-nginx
 
     ./networking.nix
     ./kubernetes.nix

--- a/machine-templates/darkmore-control-plane/kubernetes.nix
+++ b/machine-templates/darkmore-control-plane/kubernetes.nix
@@ -84,6 +84,7 @@
         control-plane-endpoints = map (hostname: "${hostname}:6443") control-plane-hostnames;
       in
       {
+        enable = true;
         streamConfig = ''
           upstream k8s_control_plane {
               ${lib.strings.join "" (map (endpoint: "server ${endpoint};") control-plane-endpoints)};

--- a/machine-templates/darkmore-control-plane/kubernetes.nix
+++ b/machine-templates/darkmore-control-plane/kubernetes.nix
@@ -46,6 +46,15 @@
             iptables
             socat
           ];
+          preStart = ''
+            for f in ${pkgs.cni-plugins}/bin/*; do
+              plugin_name=$(basename $f)
+
+              [ -f "$plugin_name" ] && rm "/opt/cni/bin/$plugin_name"
+                
+              ln -s "$f" "/opt/cni/bin/$plugin_name"
+            done
+          '';
           serviceConfig = {
             MemoryAccounting = true;
             Restart = "on-failure";
@@ -114,12 +123,9 @@
         10256 # kube-proxy
         10257 # kube-controller-manager
         10259 # kube-scheduler
-
-        4240 # cilium - health checks
-        4250 # cilium - mutual authentication port
       ];
       allowedUDPPorts = [
-        8472 # cilium - VXLAN
+        8472 # VXLAN
       ];
       allowedTCPPortRanges = [
         {

--- a/roles/installed/nix.nix
+++ b/roles/installed/nix.nix
@@ -15,7 +15,7 @@
           let
             hosts = flake.hosts.builds-hosts;
           in
-          builtins.map (x: "ssh://nix-ssh@${x}?ssh-key=${config.age.secrets.nix-serve-ssh-key.path}") hosts;
+          map (x: "ssh://nix-ssh@${x}?ssh-key=${config.age.secrets.nix-serve-ssh-key.path}") hosts;
         fallback = true;
       };
     };

--- a/terraform/tailscale.tf
+++ b/terraform/tailscale.tf
@@ -88,24 +88,6 @@ resource "tailscale_acl" "default" {
           ip = [
             "tcp:9091", // transmission
           ]
-        },
-        {
-          src = ["tag:kubernetes-darkmore-control-plane"],
-          dst = ["tag:kubernetes-darkmore-control-plane"],
-          ip = [
-            "tcp:6443",        // k8s API server
-            "tcp:2379-2380",   // etcd
-            "tcp:10250",       // kubelet API
-            "tcp:10256",       // kube-proxy
-            "tcp:10257",       // kube-controller-manager
-            "tcp:10259",       // kube-scheduler
-            "tcp:30000-32767", // NodePort services
-            "udp:30000-32767", // NodePort services
-
-            "tcp:4240", // cilium - health checks
-            "tcp:4250", // cilium - mutual authentication port
-            "udp:8472", // cilium - VXLAN
-          ]
         }
       ],
       tagOwners = {


### PR DESCRIPTION
This role provides ssl certificates, which are rate limited with low-ish limits, which leads to trouble when a machine is rebuilt a lot. These certs aren't used anyway, as nginx is load-balancing over TCP.