### PR TITLE
terraform/kubernetes: allow redis to ignore anti-affinity rules

### DIFF
--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -104,6 +104,10 @@ resource "helm_release" "argo-cd" {
       value = true
     },
     {
+      name  = "redis-ha.hardAntiAffinity",
+      value = false
+    },
+    {
       name  = "controller.replicas",
       value = 1
     },


### PR DESCRIPTION
With three nodes it just can't redeploy, which is suboptimal. Also, three replicas are excessive for this deployment size.