### PR TITLE
kubernetes/tailscale: rename the proxygroup

### DIFF
--- a/kubernetes/darkmore/tailscale-ingress/proxygroup.yaml
+++ b/kubernetes/darkmore/tailscale-ingress/proxygroup.yaml
@@ -1,7 +1,7 @@
 apiVersion: tailscale.com/v1alpha1
 kind: ProxyGroup
 metadata:
-  name: tailscale-proxygroup
+  name: service-ingress
 spec:
   type: ingress
   replicas: 2

--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -120,7 +120,7 @@ resource "helm_release" "argo-cd" {
         ingressClassName = "tailscale",
         tls              = true,
         annotations = {
-          "tailscale.com/proxy-group" = "tailscale-proxygroup"
+          "tailscale.com/proxy-group" = "service-ingress"
         }
       }
     },


### PR DESCRIPTION
this is so that it gets recreated and the new tags get applied to the services