### PR TITLE
kubernetes: disable fluent-operator's monitor, as it apparently doesn…

### DIFF
--- a/terraform/k8s/logging.tf
+++ b/terraform/k8s/logging.tf
@@ -7,7 +7,6 @@ resource "helm_release" "fluent-operator" {
 
   values = [yamlencode({
     operator = {
-      serviceMonitor = { enable = true }
       resources = {
         limits = {
           memory = "512Mi"


### PR DESCRIPTION
…'t really exist