### PR TITLE
kubernetes: move postgres to hcloud volumes

### DIFF
--- a/terraform/k8s/postgres.tf
+++ b/terraform/k8s/postgres.tf
@@ -28,7 +28,7 @@ resource "helm_release" "cloudnative-pg-database" {
   values = [yamlencode({
     cluster = {
       instances = 3
-      storage   = { size = "8Gi", storageClass = "longhorn" }
+      storage   = { size = "20Gi", storageClass = "hcloud-volumes" }
       monitoring = {
         enabled = true
       }


### PR DESCRIPTION
Longhorn is too much trouble for the DB, it will still be useful for all sorts of random stuff that needs to stay smaller than 10GB tho.