### PR TITLE
kubernetes: make crowdsec stop crashing

### DIFF
--- a/terraform/k8s/crowdsec.tf
+++ b/terraform/k8s/crowdsec.tf
@@ -19,6 +19,7 @@ resource "helm_release" "crowdsec" {
           log_format = "json"
         }
         api = {
+          client = { unregister_on_exit = true }
           server = {
             auto_registration = {
               enabled = true
@@ -39,8 +40,8 @@ resource "helm_release" "crowdsec" {
           host     = "cloudnative-pg-database-cluster-pooler-rw.cloudnative-pg-database"
           flush = {
             agents_autodelete = {
-              login_password = "1m"
-              cert           = "1m"
+              login_password = "2m"
+              cert           = "2m"
             }
             bouncers_autodelete = {
               api_key = "60m"


### PR DESCRIPTION
Heartbeats are sent every minute, therefore 1 minute can be too short of a time to live for agents, and can lead to race conditions. With 2 minutes we should be able to avoid situations in which the agent gets removed from the database while the pod is still running.