### PR TITLE
kubernetes: add a pod disruption budget to grafana

### DIFF
--- a/terraform/k8s_grafana.tf
+++ b/terraform/k8s_grafana.tf
@@ -15,6 +15,9 @@ resource "helm_release" "grafana" {
         parentRefs = [{ name = "gateway-tailscale", namespace = "kgateway-system" }]
       }
     }
+    podDisruptionBudget = {
+      minAvailable = 1
+    }
     serviceMonitor = { enabled = true }
     plugins        = ["yesoreyeram-infinity-datasource"]
     persistence = {


### PR DESCRIPTION
It becomes unavailable for a few moments during node restarts sometimes, hopefully this resolves the issue.