### PR TITLE
nix: remove the ssh substituter at hallewell

### DIFF
--- a/users/ramona/home-manager/wsl/nix.nix
+++ b/users/ramona/home-manager/wsl/nix.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  flake,
   config,
   ...
 }:
@@ -32,15 +31,10 @@
           "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           "main:9Q1Mm+tViVquBw+Q8B5BMsCbOhE2Ig3PcVJvm4BMuRs="
         ];
-        substituters =
-          let
-            hosts = flake.hosts.builds-hosts;
-          in
-          (map (x: "ssh://nix-ssh@${x}") hosts)
-          ++ [
-            "https://cache.nixos.org/"
-            "https://attic.infrastructure.ramona.fun/main"
-          ];
+        substituters = [
+          "https://cache.nixos.org/"
+          "https://attic.infrastructure.ramona.fun/main"
+        ];
         fallback = true;
       };
     };


### PR DESCRIPTION
Attic will contain everything that is needed.
Doing this only for WSL first, as it's easier to recover if something turns out to not work.